### PR TITLE
Feature: Embed published react-uswds storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -20,6 +20,13 @@ const config: StorybookConfig = {
     "../node_modules/@uswds",
     "../node_modules/@uswds/uswds/packages"
   ],
+  refs: {
+    "uswds-react": {
+      title: "USWDS React from Trussworks",
+      url: "https://trussworks.github.io/react-uswds/",
+      expanded: false
+    },
+  },
   async viteFinal(config) {
     const { mergeConfig } = await import('vite');
 


### PR DESCRIPTION
<!-- Welcome and thanks for creating a pull request! -->
<!-- Please fill out the information below. -->

## Description

Embed the published `react-uswds` Storybook as an external reference inside our local Storybook.

## Related Issues

Closes #5.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please explain):

## Solution

Used [Storybook Composition](https://storybook.js.org/docs/sharing/storybook-composition) to embed the published version of react-uswds.

## How did you test?

1. Run Storybook locally: `npm run storybook`.
2. Open the Storybook UI and confirm a new “USWDS React from Trussworks” section appears in the left nav.
    ![capture-dLAEY14N-2025-09-26@2x](https://github.com/user-attachments/assets/90c60a61-d209-4942-ad78-bf9364eeaf85)

4. Click into the external ref and everything loads correctly.

## Checklist

- [x] I've done a self-review of my code
- [ ] I've updated the docs
